### PR TITLE
Add timezone postfix and datetime shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,10 @@
 # Changelog
 
-## [v0.73.0](https://github.com/RhetTbull/osxphotos/compare/v0.73.0...v0.72.1)
+## Unreleased
 
-### v0.73.0 (2025-06-17)
+### Added
 
-#### Added
-
-- Template system supports `.utc` and `.local` postfixes for datetime fields.
-- Shortcut datetime subfields now work on all nested attributes.
-
-#### Changed
-
-#### Removed
-
-#### Fixed
-
-#### Contributors
+- Template system supports `.utc` and `.local` postfixes for all datetime fields and enables shortcut subfields on nested attributes. (Fixes #1791, #1785)
 
 
 All notable changes to this project will be documented in this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [v0.73.0](https://github.com/RhetTbull/osxphotos/compare/v0.73.0...v0.72.1)
+
+### v0.73.0 (2025-06-17)
+
+#### Added
+
+- Template system supports `.utc` and `.local` postfixes for datetime fields.
+- Shortcut datetime subfields now work on all nested attributes.
+
+#### Changed
+
+#### Removed
+
+#### Fixed
+
+#### Contributors
+
+
 All notable changes to this project will be documented in this file.
 
 ## [v0.72.1](https://github.com/RhetTbull/osxphotos/compare/v0.72.1...v0.72.0)

--- a/README.md
+++ b/README.md
@@ -2793,6 +2793,7 @@ All template fields that return a date or time value support a `.utc` or `.local
 
   {created.utc.strftime,%Y-%m-%dT%H%M%SZ}
   {photo.date_added.local.year}
+  {photo.date_added.utc.year}
 
 Using `.utc` or `.local` without a subfield returns the same output as the base field
 for top-level dates (for example, `{created}` and `{created.utc}` both render to

--- a/README.md
+++ b/README.md
@@ -2794,6 +2794,11 @@ All template fields that return a date or time value support a `.utc` or `.local
   {created.utc.strftime,%Y-%m-%dT%H%M%SZ}
   {photo.date_added.local.year}
 
+Using `.utc` or `.local` without a subfield returns the same output as the base field
+for top-level dates (for example, `{created}` and `{created.utc}` both render to
+`YYYY-MM-DD`). For nested attributes like `{photo.date_added.utc}`, the value is
+returned in full ISO format converted to the specified timezone.
+
 Nested date attributes such as `{photo.date_added}` also expose the shortcut subfields like `year`, `yy`, `mm`, `dd`, and `strftime`.
 
 <!-- OSXPHOTOS-TEMPLATE-HELP:END -->

--- a/README.md
+++ b/README.md
@@ -2787,6 +2787,15 @@ If you need to use a `%` (percent sign character), you can escape the percent si
 
 `{title[:,%%]}` replaces the `:` with `%` and `{title contains Foo?{title}{percent},{title}}` adds `%` to the  title if it contains `Foo`.
 
+### Controlling Time Zones
+
+All template fields that return a date or time value support a `.utc` or `.local` postfix to convert the value before applying subfields. Example::
+
+  {created.utc.strftime,%Y-%m-%dT%H%M%SZ}
+  {photo.date_added.local.year}
+
+Nested date attributes such as `{photo.date_added}` also expose the shortcut subfields like `year`, `yy`, `mm`, `dd`, and `strftime`.
+
 <!-- OSXPHOTOS-TEMPLATE-HELP:END -->
 
 The following template field substitutions are availabe for use the templating system.

--- a/docsrc/source/template_help.rst
+++ b/docsrc/source/template_help.rst
@@ -181,6 +181,7 @@ All template fields that return a date or time support a ``.utc`` or ``.local`` 
 
   {created.utc.strftime,%Y-%m-%dT%H%M%SZ}
   {photo.date_added.local.year}
+  {photo.date_added.utc.year}
 
 Using ``.utc`` or ``.local`` without a subfield returns the same output as the base
 field for top-level dates. For example, ``{created}`` and ``{created.utc}`` both

--- a/docsrc/source/template_help.rst
+++ b/docsrc/source/template_help.rst
@@ -182,6 +182,11 @@ All template fields that return a date or time support a ``.utc`` or ``.local`` 
   {created.utc.strftime,%Y-%m-%dT%H%M%SZ}
   {photo.date_added.local.year}
 
+Using ``.utc`` or ``.local`` without a subfield returns the same output as the base
+field for top-level dates. For example, ``{created}`` and ``{created.utc}`` both
+resolve to ``YYYY-MM-DD``. Nested attributes like ``{photo.date_added.utc}``
+return the full ISO timestamp converted to the specified timezone.
+
 Nested date attributes such as ``{photo.date_added}`` automatically support the same shortcut subfields as the top-level date fields (``year``, ``yy``, ``mm``, ``dd``, ``strftime``, etc.).
 
 

--- a/docsrc/source/template_help.rst
+++ b/docsrc/source/template_help.rst
@@ -174,6 +174,17 @@ If you need to use a ``%`` (percent sign character), you can escape the percent 
 
 ``{title[:,%%]}`` replaces the ``:`` with ``%`` and ``{title contains Foo?{title}{percent},{title}}`` adds ``%`` to the  title if it contains ``Foo``.
 
+Controlling Time Zones
+----------------------
+
+All template fields that return a date or time support a ``.utc`` or ``.local`` postfix to convert the value to UTC or the host's local timezone before any subfields are applied.  For example::
+
+  {created.utc.strftime,%Y-%m-%dT%H%M%SZ}
+  {photo.date_added.local.year}
+
+Nested date attributes such as ``{photo.date_added}`` automatically support the same shortcut subfields as the top-level date fields (``year``, ``yy``, ``mm``, ``dd``, ``strftime``, etc.).
+
+
 Template Substitutions
 ----------------------
 

--- a/examples/demo_tz_postfix.py
+++ b/examples/demo_tz_postfix.py
@@ -1,7 +1,10 @@
+import os
 import osxphotos
 from osxphotos.phototemplate import RenderOptions
 
-PHOTOS_DB = "./tests/Test-16.0.0-beta.photoslibrary/database/photos.db"
+PHOTOS_DB = os.environ.get(
+    "PHOTOS_DB", "./tests/Test-16.0.0-beta.photoslibrary/database/photos.db"
+)
 UUID = "6F570409-7B94-4D89-AFC6-D04BF11E5EA8"
 
 

--- a/examples/demo_tz_postfix.py
+++ b/examples/demo_tz_postfix.py
@@ -19,6 +19,7 @@ def main():
         "{created.local}",
         "{photo.date_added}",
         "{photo.date_added.utc}",
+        "{photo.date_added.local.year}",
         "{photo.date_modified}",
         "{photo.date_modified.utc}",
     ]

--- a/examples/demo_tz_postfix.py
+++ b/examples/demo_tz_postfix.py
@@ -1,0 +1,28 @@
+import osxphotos
+from osxphotos.phototemplate import RenderOptions
+
+PHOTOS_DB = "./tests/Test-16.0.0-beta.photoslibrary/database/photos.db"
+UUID = "6F570409-7B94-4D89-AFC6-D04BF11E5EA8"
+
+
+def main():
+    photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
+    photo = photosdb.photos(uuid=[UUID])[0]
+    template = osxphotos.PhotoTemplate(photo)
+    options = RenderOptions()
+    fields = [
+        "{created}",
+        "{created.utc}",
+        "{created.local}",
+        "{photo.date_added}",
+        "{photo.date_added.utc}",
+        "{photo.date_modified}",
+        "{photo.date_modified.utc}",
+    ]
+    for f in fields:
+        rendered, _ = template.render(f, options)
+        print(f"{f} => {rendered[0]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/osxphotos/_version.py
+++ b/osxphotos/_version.py
@@ -1,3 +1,3 @@
 """ version info """
 
-__version__ = "0.72.1"
+__version__ = "0.73.0"

--- a/osxphotos/_version.py
+++ b/osxphotos/_version.py
@@ -1,3 +1,3 @@
 """ version info """
 
-__version__ = "0.73.0"
+__version__ = "0.72.1"

--- a/osxphotos/phototemplate.cog.md
+++ b/osxphotos/phototemplate.cog.md
@@ -150,5 +150,10 @@ All template fields that return a datetime support a `.utc` or `.local` postfix 
   {created.utc.strftime,%Y-%m-%dT%H%M%SZ}
   {photo.date_added.local.year}
 
+Using `.utc` or `.local` without a subfield returns the same output as the base
+field for top-level dates (e.g. `{created}` and `{created.utc}` both resolve to
+`YYYY-MM-DD`). For nested attributes like `{photo.date_added.utc}`, the value is
+returned in full ISO format converted to the specified timezone.
+
 Nested date attributes such as `{photo.date_added}` also expose the shortcut subfields like `year`, `yy`, `mm`, `dd`, and `strftime`.
 

--- a/osxphotos/phototemplate.cog.md
+++ b/osxphotos/phototemplate.cog.md
@@ -149,6 +149,7 @@ All template fields that return a datetime support a `.utc` or `.local` postfix 
 
   {created.utc.strftime,%Y-%m-%dT%H%M%SZ}
   {photo.date_added.local.year}
+  {photo.date_added.utc.year}
 
 Using `.utc` or `.local` without a subfield returns the same output as the base
 field for top-level dates (e.g. `{created}` and `{created.utc}` both resolve to

--- a/osxphotos/phototemplate.cog.md
+++ b/osxphotos/phototemplate.cog.md
@@ -141,3 +141,14 @@ Variables can also be referenced as fields in the template string, for example: 
 If you need to use a `%` (percent sign character), you can escape the percent sign by using `%%`.  You can also use the `{percent}` template field where a template field is required. For example:
 
 `{title[:,%%]}` replaces the `:` with `%` and `{title contains Foo?{title}{percent},{title}}` adds `%` to the  title if it contains `Foo`.
+
+Controlling Time Zones
+----------------------
+
+All template fields that return a datetime support a `.utc` or `.local` postfix to explicitly convert the value before applying any subfields. For example::
+
+  {created.utc.strftime,%Y-%m-%dT%H%M%SZ}
+  {photo.date_added.local.year}
+
+Nested date attributes such as `{photo.date_added}` also expose the shortcut subfields like `year`, `yy`, `mm`, `dd`, and `strftime`.
+

--- a/osxphotos/phototemplate.py
+++ b/osxphotos/phototemplate.py
@@ -40,6 +40,27 @@ __all__ = [
     "format_str_value",
 ]
 
+# postfix constants for timezone conversion
+UTC_POSTFIX = "utc"
+LOCAL_POSTFIX = "local"
+
+# subfields valid for datetime objects
+DATETIME_SUBFIELDS = {
+    "date",
+    "year",
+    "yy",
+    "mm",
+    "month",
+    "mon",
+    "dd",
+    "dow",
+    "doy",
+    "hour",
+    "min",
+    "sec",
+    "strftime",
+}
+
 # TODO: a lot of values are passed from function to function like path_sep--make these all class properties
 
 # ensure locale set to user's locale
@@ -869,7 +890,7 @@ class PhotoTemplate:
             )
         elif field in MULTI_VALUE_SUBSTITUTIONS or field.startswith("photo"):
             vals = self.get_template_value_multi(
-                field, subfield, path_sep=field_arg, default=default
+                field, subfield, path_sep=field_arg, default=default, field_arg=field_arg
             )
         elif field.split(".")[0] in PATHLIB_SUBSTITUTIONS:
             vals = self.get_template_value_pathlib(field)
@@ -911,7 +932,15 @@ class PhotoTemplate:
         # wouldn't a switch/case statement be nice...
         # handle the fields that don't require a PhotoInfo object first
         if field.startswith("today"):
-            value = format_date_field(self.today, field, default)
+            parts = field.split(".")
+            dt = self.today
+            if len(parts) > 1 and parts[1] in (UTC_POSTFIX, LOCAL_POSTFIX):
+                tz = parts[1]
+                dt = dt.astimezone(datetime.timezone.utc) if tz == UTC_POSTFIX else dt.astimezone()
+                new_field = "today" + ("." + ".".join(parts[2:]) if len(parts) > 2 else "")
+            else:
+                new_field = field
+            value = format_date_field(dt, new_field, default)
         elif field in PUNCTUATION:
             value = PUNCTUATION[field]
         elif field == "osxphotos_version":
@@ -943,12 +972,26 @@ class PhotoTemplate:
         elif field == "favorite":
             value = "favorite" if self.photo.favorite else None
         elif field.startswith("created"):
-            value = format_date_field(self.photo.date, field, default)
+            parts = field.split(".")
+            dt = self.photo.date
+            if len(parts) > 1 and parts[1] in (UTC_POSTFIX, LOCAL_POSTFIX):
+                tz = parts[1]
+                dt = dt.astimezone(datetime.timezone.utc) if tz == UTC_POSTFIX else dt.astimezone()
+                new_field = "created" + ("." + ".".join(parts[2:]) if len(parts) > 2 else "")
+            else:
+                new_field = field
+            value = format_date_field(dt, new_field, default)
         elif field.startswith("modified"):
             # if no modified date, use photo.date
-            value = format_date_field(
-                self.photo.date_modified or self.photo.date, field, default
-            )
+            mod_dt = self.photo.date_modified or self.photo.date
+            parts = field.split(".")
+            if len(parts) > 1 and parts[1] in (UTC_POSTFIX, LOCAL_POSTFIX):
+                tz = parts[1]
+                mod_dt = mod_dt.astimezone(datetime.timezone.utc) if tz == UTC_POSTFIX else mod_dt.astimezone()
+                new_field = "modified" + ("." + ".".join(parts[2:]) if len(parts) > 2 else "")
+            else:
+                new_field = field
+            value = format_date_field(mod_dt, new_field, default)
         elif field.startswith("place"):
             value = get_place_value(self.photo, field)
         elif field == "searchinfo.season":
@@ -1214,7 +1257,7 @@ class PhotoTemplate:
 
         return predicate_is_true
 
-    def get_template_value_multi(self, field, subfield, path_sep, default):
+    def get_template_value_multi(self, field, subfield, path_sep, default, field_arg=None):
         """lookup value for template field (multi-value template substitutions)
 
         Args:
@@ -1331,8 +1374,25 @@ class PhotoTemplate:
                     "Missing property in {photo} template.  Use in form {photo.property}."
                 )
             obj = self.photo
-            for i in range(1, len(properties)):
-                property_ = properties[i]
+            idx = 1
+            while idx < len(properties):
+                property_ = properties[idx]
+                if isinstance(obj, datetime.datetime):
+                    if property_ == UTC_POSTFIX:
+                        obj = obj.astimezone(datetime.timezone.utc)
+                        idx += 1
+                        continue
+                    if property_ == LOCAL_POSTFIX:
+                        obj = obj.astimezone()
+                        idx += 1
+                        continue
+                    if property_ in DATETIME_SUBFIELDS:
+                        arg = field_arg if property_ == "strftime" else None
+                        obj = format_datetime_subfield(obj, property_, arg)
+                        idx += 1
+                        if idx != len(properties):
+                            raise ValueError(f"Unhandled template value: {field}")
+                        break
                 try:
                     obj = getattr(obj, property_)
                     if obj is None:
@@ -1341,9 +1401,12 @@ class PhotoTemplate:
                     raise ValueError(
                         "Invalid property for {photo} template: " + f"'{property_}'"
                     ) from e
+                idx += 1
 
             if obj is None:
                 values = []
+            elif isinstance(obj, datetime.datetime):
+                values = [obj.isoformat()]
             elif isinstance(obj, bool):
                 values = [property_] if obj else []
             elif isinstance(obj, (str, int, float)):
@@ -1711,6 +1774,22 @@ def values_to_float(values: List[str]) -> List[str]:
         with suppress(ValueError):
             float_values.append(str(float(v)))
     return float_values
+
+
+def format_datetime_subfield(dt: datetime.datetime, subfield: str, arg: str | None) -> str:
+    """Return string for datetime subfield."""
+
+    if subfield == "strftime":
+        if not arg:
+            return None
+        try:
+            return dt.strftime(arg)
+        except Exception as e:  # pragma: no cover - invalid format
+            raise ValueError(f"Invalid strftime template: '{arg}'") from e
+    try:
+        return getattr(DateTimeFormatter(dt), subfield)
+    except AttributeError as e:
+        raise ValueError(f"Unhandled datetime subfield: {subfield}") from e
 
 
 def format_date_field(dt: datetime.datetime, field: str, args: List[str]) -> str:

--- a/osxphotos/phototemplate.py
+++ b/osxphotos/phototemplate.py
@@ -44,6 +44,19 @@ __all__ = [
 UTC_POSTFIX = "utc"
 LOCAL_POSTFIX = "local"
 
+
+def apply_tz_postfix(dt: datetime.datetime, parts: list[str]) -> tuple[datetime.datetime, list[str]]:
+    """Apply timezone postfix to dt if parts[1] is UTC_POSTFIX or LOCAL_POSTFIX.
+
+    Returns a tuple of the converted datetime and the remaining parts list
+    (with the postfix removed if it was present)."""
+
+    if len(parts) > 1 and parts[1] in (UTC_POSTFIX, LOCAL_POSTFIX):
+        tz = parts[1]
+        dt = dt.astimezone(datetime.timezone.utc) if tz == UTC_POSTFIX else dt.astimezone()
+        parts = [parts[0]] + parts[2:]
+    return dt, parts
+
 # subfields valid for datetime objects
 # derived from DateTimeFormatter to avoid duplication
 DATETIME_SUBFIELDS = {
@@ -924,14 +937,8 @@ class PhotoTemplate:
         # handle the fields that don't require a PhotoInfo object first
         if field.startswith("today"):
             parts = field.split(".")
-            dt = self.today
-            if len(parts) > 1 and parts[1] in (UTC_POSTFIX, LOCAL_POSTFIX):
-                tz = parts[1]
-                dt = dt.astimezone(datetime.timezone.utc) if tz == UTC_POSTFIX else dt.astimezone()
-                new_field = "today" + ("." + ".".join(parts[2:]) if len(parts) > 2 else "")
-            else:
-                new_field = field
-            value = format_date_field(dt, new_field, default)
+            dt, parts = apply_tz_postfix(self.today, parts)
+            value = format_date_field(dt, ".".join(parts), default)
         elif field in PUNCTUATION:
             value = PUNCTUATION[field]
         elif field == "osxphotos_version":
@@ -964,25 +971,14 @@ class PhotoTemplate:
             value = "favorite" if self.photo.favorite else None
         elif field.startswith("created"):
             parts = field.split(".")
-            dt = self.photo.date
-            if len(parts) > 1 and parts[1] in (UTC_POSTFIX, LOCAL_POSTFIX):
-                tz = parts[1]
-                dt = dt.astimezone(datetime.timezone.utc) if tz == UTC_POSTFIX else dt.astimezone()
-                new_field = "created" + ("." + ".".join(parts[2:]) if len(parts) > 2 else "")
-            else:
-                new_field = field
-            value = format_date_field(dt, new_field, default)
+            dt, parts = apply_tz_postfix(self.photo.date, parts)
+            value = format_date_field(dt, ".".join(parts), default)
         elif field.startswith("modified"):
             # if no modified date, use photo.date
             mod_dt = self.photo.date_modified or self.photo.date
             parts = field.split(".")
-            if len(parts) > 1 and parts[1] in (UTC_POSTFIX, LOCAL_POSTFIX):
-                tz = parts[1]
-                mod_dt = mod_dt.astimezone(datetime.timezone.utc) if tz == UTC_POSTFIX else mod_dt.astimezone()
-                new_field = "modified" + ("." + ".".join(parts[2:]) if len(parts) > 2 else "")
-            else:
-                new_field = field
-            value = format_date_field(mod_dt, new_field, default)
+            mod_dt, parts = apply_tz_postfix(mod_dt, parts)
+            value = format_date_field(mod_dt, ".".join(parts), default)
         elif field.startswith("place"):
             value = get_place_value(self.photo, field)
         elif field == "searchinfo.season":
@@ -1385,6 +1381,7 @@ class PhotoTemplate:
                             # fallback to system local timezone; Photos may store
                             # 'floating' dates without timezone info so a
                             # future enhancement could use photo.tz_offset
+                            # TODO: https://github.com/RhetTbull/osxphotos/issues/1792
                             obj = obj.astimezone()
                         if property_ == "strftime":
                             arg = field_arg or (default[0] if default else None)

--- a/osxphotos/phototemplate.py
+++ b/osxphotos/phototemplate.py
@@ -45,21 +45,12 @@ UTC_POSTFIX = "utc"
 LOCAL_POSTFIX = "local"
 
 # subfields valid for datetime objects
+# derived from DateTimeFormatter to avoid duplication
 DATETIME_SUBFIELDS = {
-    "date",
-    "year",
-    "yy",
-    "mm",
-    "month",
-    "mon",
-    "dd",
-    "dow",
-    "doy",
-    "hour",
-    "min",
-    "sec",
-    "strftime",
-}
+    name
+    for name, obj in DateTimeFormatter.__dict__.items()
+    if isinstance(obj, property)
+} | {"strftime"}
 
 # TODO: a lot of values are passed from function to function like path_sep--make these all class properties
 
@@ -1391,6 +1382,9 @@ class PhotoTemplate:
                         continue
                     if property_ in DATETIME_SUBFIELDS:
                         if not tz_applied:
+                            # fallback to system local timezone; Photos may store
+                            # 'floating' dates without timezone info so a
+                            # future enhancement could use photo.tz_offset
                             obj = obj.astimezone()
                         if property_ == "strftime":
                             arg = field_arg or (default[0] if default else None)

--- a/osxphotos/phototemplate.py
+++ b/osxphotos/phototemplate.py
@@ -1375,19 +1375,27 @@ class PhotoTemplate:
                 )
             obj = self.photo
             idx = 1
+            tz_applied = False
             while idx < len(properties):
                 property_ = properties[idx]
                 if isinstance(obj, datetime.datetime):
                     if property_ == UTC_POSTFIX:
                         obj = obj.astimezone(datetime.timezone.utc)
+                        tz_applied = True
                         idx += 1
                         continue
                     if property_ == LOCAL_POSTFIX:
                         obj = obj.astimezone()
+                        tz_applied = True
                         idx += 1
                         continue
                     if property_ in DATETIME_SUBFIELDS:
-                        arg = field_arg if property_ == "strftime" else None
+                        if not tz_applied:
+                            obj = obj.astimezone()
+                        if property_ == "strftime":
+                            arg = field_arg or (default[0] if default else None)
+                        else:
+                            arg = None
                         obj = format_datetime_subfield(obj, property_, arg)
                         idx += 1
                         if idx != len(properties):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ if OS_VER[0] == "10" and OS_VER[1] in ("15", "16"):
     TEST_LIBRARY_PHOTODATES = TEST_LIBRARY
 
     TEST_LIBRARY_ADD_LOCATIONS = None
-elif int(OS_VER[0]) >= 13:
+elif OS_VER[0] is not None and int(OS_VER[0]) >= 13:
     # Ventura
     TEST_LIBRARY = "tests/Test-13.0.0.photoslibrary"
     TEST_LIBRARY_IMPORT = TEST_LIBRARY

--- a/tests/test_template_shortcuts.py
+++ b/tests/test_template_shortcuts.py
@@ -12,8 +12,8 @@ def test_nested_date_shortcuts():
     template = osxphotos.PhotoTemplate(photo)
     options = RenderOptions()
     rendered, _ = template.render("{photo.date_added.year}", options)
-    assert rendered[0] == "2025"
+    assert rendered[0] == photo.date_added.astimezone().strftime("%Y")
     rendered, _ = template.render("{photo.date_added.yy}", options)
-    assert rendered[0] == "25"
+    assert rendered[0] == photo.date_added.astimezone().strftime("%y")
     rendered, _ = template.render("{photo.date_added.strftime,%Y-%m-%d}", options)
-    assert rendered[0] == "2025-06-11"
+    assert rendered[0] == photo.date_added.astimezone().strftime("%Y-%m-%d")

--- a/tests/test_template_shortcuts.py
+++ b/tests/test_template_shortcuts.py
@@ -1,0 +1,19 @@
+import datetime
+import osxphotos
+from osxphotos.phototemplate import RenderOptions
+
+PHOTOS_DB = "./tests/Test-16.0.0-beta.photoslibrary/database/photos.db"
+UUID = "6F570409-7B94-4D89-AFC6-D04BF11E5EA8"
+
+
+def test_nested_date_shortcuts():
+    photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
+    photo = photosdb.photos(uuid=[UUID])[0]
+    template = osxphotos.PhotoTemplate(photo)
+    options = RenderOptions()
+    rendered, _ = template.render("{photo.date_added.year}", options)
+    assert rendered[0] == "2025"
+    rendered, _ = template.render("{photo.date_added.yy}", options)
+    assert rendered[0] == "25"
+    rendered, _ = template.render("{photo.date_added.strftime,%Y-%m-%d}", options)
+    assert rendered[0] == "2025-06-11"

--- a/tests/test_template_tz_postfix.py
+++ b/tests/test_template_tz_postfix.py
@@ -44,3 +44,14 @@ def test_utc_no_subfield_same_as_default():
     rendered_default, _ = template.render("{created}", options)
     rendered_utc, _ = template.render("{created.utc}", options)
     assert rendered_default[0] == rendered_utc[0]
+
+
+def test_today_utc_dd():
+    photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
+    photo = photosdb.photos(uuid=[UUID])[0]
+    template = osxphotos.PhotoTemplate(photo)
+    template.today = datetime.datetime(2023, 1, 15, 12, 30)
+    options = RenderOptions()
+    expected = template.today.astimezone(datetime.timezone.utc).strftime("%d")
+    rendered, _ = template.render("{today.utc.dd}", options)
+    assert rendered[0] == expected

--- a/tests/test_template_tz_postfix.py
+++ b/tests/test_template_tz_postfix.py
@@ -1,0 +1,19 @@
+import datetime
+import osxphotos
+from osxphotos.phototemplate import RenderOptions
+
+PHOTOS_DB = "./tests/Test-16.0.0-beta.photoslibrary/database/photos.db"
+UUID = "6F570409-7B94-4D89-AFC6-D04BF11E5EA8"
+
+
+def test_utc_local_postfix():
+    photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
+    photo = photosdb.photos(uuid=[UUID])[0]
+    template = osxphotos.PhotoTemplate(photo)
+    options = RenderOptions()
+    dt_utc = photo.date.astimezone(datetime.timezone.utc)
+    rendered, _ = template.render("{created.utc.strftime,%Y-%m-%dT%H:%M:%S%z}", options)
+    assert rendered[0] == dt_utc.strftime("%Y-%m-%dT%H:%M:%S%z")
+    dt_local = photo.date.astimezone()
+    rendered, _ = template.render("{created.local.strftime,%Y-%m-%dT%H:%M:%S%z}", options)
+    assert rendered[0] == dt_local.strftime("%Y-%m-%dT%H:%M:%S%z")

--- a/tests/test_template_tz_postfix.py
+++ b/tests/test_template_tz_postfix.py
@@ -17,3 +17,30 @@ def test_utc_local_postfix():
     dt_local = photo.date.astimezone()
     rendered, _ = template.render("{created.local.strftime,%Y-%m-%dT%H:%M:%S%z}", options)
     assert rendered[0] == dt_local.strftime("%Y-%m-%dT%H:%M:%S%z")
+
+
+def test_nested_date_tz_postfix():
+    photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
+    photo = photosdb.photos(uuid=[UUID])[0]
+    template = osxphotos.PhotoTemplate(photo)
+    options = RenderOptions()
+    dt_utc = photo.date_added.astimezone(datetime.timezone.utc)
+    rendered, _ = template.render("{photo.date_added.utc.strftime,%Y-%m-%dT%H:%M:%S%z}", options)
+    assert rendered[0] == dt_utc.strftime("%Y-%m-%dT%H:%M:%S%z")
+    rendered, _ = template.render("{photo.date_added.utc.year}", options)
+    assert rendered[0] == dt_utc.strftime("%Y")
+    dt_local = photo.date_added.astimezone()
+    rendered, _ = template.render("{photo.date_added.local.strftime,%Y-%m-%dT%H:%M:%S%z}", options)
+    assert rendered[0] == dt_local.strftime("%Y-%m-%dT%H:%M:%S%z")
+    rendered, _ = template.render("{photo.date_added.local.year}", options)
+    assert rendered[0] == dt_local.strftime("%Y")
+
+
+def test_utc_no_subfield_same_as_default():
+    photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
+    photo = photosdb.photos(uuid=[UUID])[0]
+    template = osxphotos.PhotoTemplate(photo)
+    options = RenderOptions()
+    rendered_default, _ = template.render("{created}", options)
+    rendered_utc, _ = template.render("{created.utc}", options)
+    assert rendered_default[0] == rendered_utc[0]


### PR DESCRIPTION
## Summary
- implement `.utc` and `.local` postfix for all datetime template fields
- enable shortcut subfields on nested datetime attributes
- document timezone control and bump version to 0.73.0

## Testing
- `ruff check osxphotos/phototemplate.py`
- `ruff check tests/test_template_shortcuts.py tests/test_template_tz_postfix.py`
- `PYTHONPATH=. pytest tests/test_template_shortcuts.py::test_nested_date_shortcuts -q` *(fails: ImportError while loading conftest)*

------
https://chatgpt.com/codex/tasks/task_e_685338ba784883309ed78c74fed506aa